### PR TITLE
refactor: move isDev constant

### DIFF
--- a/src/utils/MinimizeDfa.ts
+++ b/src/utils/MinimizeDfa.ts
@@ -264,15 +264,15 @@ function removeStates(dfa: any, states: string[]) {
 function preprocessDfa(dfa: any) {
 
     let newDfa = (JSON.parse(JSON.stringify(dfa)));
-  if (isDev) {
-    console.log('Before Preprocess:');
-    console.log(dfa.state);
-    console.log(dfa);
-    console.log(JSON.stringify(dfa));
-  }
+    if (isDev) {
+      console.log('Before Preprocess:');
+      console.log(dfa.state);
+      console.log(dfa);
+      console.log(JSON.stringify(dfa));
+    }
 
-  // Sort dfa.state
-  dfa.state.sort();
+    // Sort dfa.state
+    dfa.state.sort();
 
     // Convert all transition elements from array to string
     for (const state in dfa.transitions) {

--- a/src/utils/NfaToDfa.ts
+++ b/src/utils/NfaToDfa.ts
@@ -2,6 +2,7 @@
 const dfa_prefix = "Q";
 // delcare epsilon close symbol
 const epsilon = "ε";
+const isDev = process.env.NODE_ENV === 'development';
 
 function arrayExistsAsObjectValue(targetObject: any, arrayParam: any) {
     const sortedArrayParam = JSON.stringify(arrayParam.sort());
@@ -94,8 +95,6 @@ function transition_function(fa: any, state: any, symbol: any): any {
  * @param fa e.g. {"type":"","transitions":{"q2":{"a":["q1"],"ε":[],"b":["q0"]},"q1":{"b":[],"ε":["q2"],"a":["q1"]},"q0":{"b":["q0"],"ε":["q1"],"a":[]}},"symbols":["a","b","ε"],"start_state":"q0","name":"q0q1q2 Valid ","end_states":["q2"],"state":["q0","q1","q2"]}
  * @returns e.g. {"name":"q0q1q2 Valid ","type":"dfa","transitions":{"q_prime_0":{"a":["q_prime_1"],"b":["q_prime_0"]},"q_prime_1":{"a":["q_prime_1"],"b":["q_prime_0"]},"q_prime_2":{"a":["q_prime_1"],"b":["q_prime_0"]}},"symbols":["a","b"],"state":["q_prime_0","q_prime_1","q_prime_2"],"end_states":["q_prime_2"],"start_state":"q_prime_0"}
  */
-const isDev = process.env.NODE_ENV === 'development';
-
 function nfaToDfa(fa: any): any {
 
     let endOfDfa = false;


### PR DESCRIPTION
## Summary
- move isDev constant in NFA to DFA utility to module scope to avoid redeclaration
- fix console log indentation in DFA minimization preprocessing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b326a842c4832ba15369e6f8f223fc